### PR TITLE
Add metadata to mark peer dependencies as optional for npm7+

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,14 @@
     "iltorb": "^2.0.0",
     "node-zopfli-es": "^1.0.3"
   },
+  "peerDependenciesMeta": {
+    "iltorb": {
+      "optional": true
+    },
+    "node-zopfli-es": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=8.0"
   },


### PR DESCRIPTION
In npm 7 and npm 8, peer dependencies are installed by default.

iltorb and node-zopfli-es are only required for older versions of Node, and it doesn't make sense for them to be installed automatically when shrink-ray-current is installed.

This change adds a peerDependenciesMeta field to mark these peer dependencies as optional https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependenciesmeta